### PR TITLE
Correct protocol violation to event callback.

### DIFF
--- a/src/mero_wrk_tcp_binary.erl
+++ b/src/mero_wrk_tcp_binary.erl
@@ -253,8 +253,6 @@ recv_bytes(Client, NumBytes, TimeLimit) ->
         {ok, Bin} -> Bin;
       {error, Reason} ->
         ?LOG_EVENT(Client#client.event_callback, {[memcached_receive_error], [{reason, Reason}]}),
-        error_logger:error_report([{error, receive_bytes_from_memcached_socket},
-          {reason, Reason}]),
         throw({failed, {receive_bytes, Reason}})
     end.
 

--- a/src/mero_wrk_tcp_binary.erl
+++ b/src/mero_wrk_tcp_binary.erl
@@ -252,7 +252,7 @@ recv_bytes(Client, NumBytes, TimeLimit) ->
     case gen_tcp_recv(Client#client.socket, NumBytes, Timeout) of
         {ok, Bin} -> Bin;
       {error, Reason} ->
-        ?LOG_EVENT(Client#client.event_callback, {memcached_receive_error, Reason}),
+        ?LOG_EVENT(Client#client.event_callback, {[memcached_receive_error], [{reason, Reason}]}),
         error_logger:error_report([{error, receive_bytes_from_memcached_socket},
           {reason, Reason}]),
         throw({failed, {receive_bytes, Reason}})


### PR DESCRIPTION
I think this is correct, anyhow. A client project suffered a crash as a
result.

Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>