### PR TITLE
Warnings everywhere from binary protocol.

### DIFF
--- a/src/mero_wrk_tcp_binary.erl
+++ b/src/mero_wrk_tcp_binary.erl
@@ -155,10 +155,6 @@ send_receive(Client, {Op, _Args} = Cmd, TimeLimit) ->
         receive_response(Client, Op, TimeLimit)
     catch
         throw:{failed, Reason} ->
-          error_logger:warning_report([{error, memcached_request_failed},
-            {client, Client},
-            {cmd, Cmd},
-            {reason, Reason}]),
           {error, Reason}
     end.
 
@@ -206,8 +202,6 @@ send(Client, Data) ->
         ok -> ok;
         {error, Reason} ->
           ?LOG_EVENT(Client#client.event_callback, {memcached_send_error, Reason}),
-          error_logger:warning_report([{error, send_error},
-            {error, Reason}]),
           throw({failed, {send, Reason}})
     end.
 
@@ -231,17 +225,9 @@ receive_response(Client, Op, TimeLimit) ->
                     Status ->  throw({failed, {response_status, Status}})
                   end;
               Data ->
-                error_logger:warning_report([{error, unexpected_body_from_memcached_socket},
-                    {operation, Op},
-                  {Data, Data}]),
                 throw({failed, {unexpected_body, Data}})
             end;
       Data ->
-
-        error_logger:warning_report(
-            [{error, unexpected_header_from_memcached_socket},
-             {operation, Op},
-             {Data, Data}]),
         throw({failed, {unexpected_header, Data}})
     end.
 

--- a/src/mero_wrk_tcp_binary.erl
+++ b/src/mero_wrk_tcp_binary.erl
@@ -155,7 +155,7 @@ send_receive(Client, {Op, _Args} = Cmd, TimeLimit) ->
         receive_response(Client, Op, TimeLimit)
     catch
         throw:{failed, Reason} ->
-          error_logger:error_report([{error, memcached_request_failed},
+          error_logger:warning_report([{error, memcached_request_failed},
             {client, Client},
             {cmd, Cmd},
             {reason, Reason}]),
@@ -206,7 +206,7 @@ send(Client, Data) ->
         ok -> ok;
         {error, Reason} ->
           ?LOG_EVENT(Client#client.event_callback, {memcached_send_error, Reason}),
-          error_logger:error_report([{error, send_error},
+          error_logger:warning_report([{error, send_error},
             {error, Reason}]),
           throw({failed, {send, Reason}})
     end.
@@ -231,14 +231,14 @@ receive_response(Client, Op, TimeLimit) ->
                     Status ->  throw({failed, {response_status, Status}})
                   end;
               Data ->
-                error_logger:error_report([{error, unexpected_body_from_memcached_socket},
+                error_logger:warning_report([{error, unexpected_body_from_memcached_socket},
                     {operation, Op},
                   {Data, Data}]),
                 throw({failed, {unexpected_body, Data}})
             end;
       Data ->
 
-        error_logger:error_report(
+        error_logger:warning_report(
             [{error, unexpected_header_from_memcached_socket},
              {operation, Op},
              {Data, Data}]),


### PR DESCRIPTION
This is a fairly aggressive change. The intention is that error reports
at the bottom of the mero stack are not something that can be addressed
by an end-user, interesting though they are. This makes errors warnings.

Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>