### PR TITLE
Address some boundary issues in mero_pool.

### DIFF
--- a/src/mero_pool.erl
+++ b/src/mero_pool.erl
@@ -262,10 +262,10 @@ pool_loop(State, Parent, Deb) ->
 
 
 get_connection(#pool_st{free = Free} = State, From) when Free /= [] ->
-    maybe_spawn_connect(give(State, From));
+    give(State, From);
 get_connection(State, {Pid, Ref} = _From) ->
     safe_send(Pid, {Ref, {reject, State}}),
-    State.
+    maybe_spawn_connect(State).
 
 
 maybe_spawn_connect(#pool_st{

--- a/test/mero_SUITE.erl
+++ b/test/mero_SUITE.erl
@@ -85,7 +85,6 @@ init_per_testcase(_Module, Conf) ->
     [{pids, Pids} | Conf].
 
 end_per_testcase(_Module, Conf) ->
-    dbg:stop_clear(),
     {ok, Pids} = proplists:get_value(pids, Conf),
     mero_test_util:stop_servers(Pids),
     mero_dummy_server:reset_all_keys(),
@@ -129,7 +128,6 @@ delete(_Conf) ->
 
 set(_Conf) ->
     ct:log("state ~p", [mero:state()]),
-    dbg(),
     ?assertMatch(ok, mero:set(cluster, <<"11">>, <<"Adroll">>, 11111, 1000)),
     ?assertMatch({<<"11">>, <<"Adroll">>}, mero:get(cluster, <<"11">>)),
 
@@ -231,7 +229,6 @@ increment(_Conf) ->
 
 add(_Conf) ->
     ?assertMatch(ok, mero:add(cluster, <<"11">>, <<"Adroll">>, 11111, 1000)),
-    dbg(),
     ct:log("First not stored"),
     ?assertMatch({error, not_stored}, mero:add(cluster, <<"11">>, <<"Adroll2">>, 111111, 1000)),
     ct:log("Second not stored"),
@@ -254,15 +251,3 @@ m() ->
 
 key() ->
     base64:encode(crypto:strong_rand_bytes(20)).
-
-%% Just for test purposes
-dbg() ->
-    dbg:tracer(),
-    dbg:p(all, c),
-    %dbg:tp(mero_cluster,x),
-    %dbg:tpl(mero_cluster_localhost_1_0,x),
-    %dbg:tp(mero_pool,x),
-    dbg:tpl(mero_dummy_server, x),
-    dbg:tpl(mero_wrk_tcp_txt, x),
-    dbg:tpl(mero_conn, x),
-    ok.

--- a/test/mero_cluster_SUITE.erl
+++ b/test/mero_cluster_SUITE.erl
@@ -60,7 +60,7 @@ init_per_testcase(_, Conf) ->
 
 
 end_per_testcase(_, _Conf) ->
-    dbg:stop_clear().
+    ok.
 
 %%%=============================================================================
 %%% Tests
@@ -170,7 +170,6 @@ group_by_shards(_Conf) ->
                 {pool_worker_module, mero_wrk_tcp_txt}]}],
     mero_cluster:load_clusters(Config),
     ?assertMatch([], mero_cluster:group_by_shards(cluster, [])),
-    dbg(),
     ?assertMatch([
         {0, [<<"6">>, <<"13">>, <<"14">>, <<"15">>, <<"17">>]},
         {1, [<<"1">>,<<"2">>,<<"3">>,<<"4">>,<<"5">>,<<"7">>,
@@ -184,10 +183,3 @@ group_by_shards(_Conf) ->
             <<"14">>, <<"15">>, <<"16">>,
             <<"17">>, <<"18">>, <<"19">>])),
     ok.
-
-dbg() ->
-    dbg:tracer(),
-    dbg:p(all,c),
-    dbg:tpl(mero_cluster,x),
-    ok.
-

--- a/test/mero_pool_SUITE.erl
+++ b/test/mero_pool_SUITE.erl
@@ -77,7 +77,6 @@ init_per_testcase(_, Conf) ->
 
 
 end_per_testcase(_, _Conf) ->
-  dbg:stop_clear(),
   application:stop(mero).
 
 %%%=============================================================================
@@ -224,7 +223,7 @@ checkout_checkin_limits(_) ->
     proc:exec(proc:new(), {mero_pool, checkout, [?POOL, ?TIMELIMIT(1000)]})),
   mero_test_util:wait_for_pool_state(?POOL, 1, 4, 0, 0),
 
-  ct:log("The first one is on use so the second one should be stablished soon"),
+  ct:log("The first one is on use so the second one should be established soon"),
   ok = mero_pool:checkin(Conn1),
   mero_test_util:wait_for_pool_state(?POOL, 2, 4, 0, 0),
 
@@ -301,12 +300,3 @@ checkout_timeout(_) ->
 %%%=============================================================================
 %%% Helper functions
 %%%=============================================================================
-
-dbg() ->
-  dbg:tracer(),
-  dbg:p(all,c),
-  dbg:tpl(mero_sup,x),
-  dbg:tpl(mero_pool,x),
-  dbg:tpl(mero,x),
-  dbg:tpl(mero_wrk,x),
-  ok.

--- a/test/mero_pool_SUITE.erl
+++ b/test/mero_pool_SUITE.erl
@@ -139,14 +139,21 @@ expire_connections(_) ->
   {ok, _Pid} = mero_test_util:start_server(?CLUSTER_CONFIG, 2, 4, 300, 900),
   mero_test_util:wait_for_pool_state(?POOL, 2, 2, 0, 0),
 
-  ct:log("Lets take two of the connections, new ones will be created"),
+  ct:log("Let's take two of the connections, no new ones will be created"),
   P1 = proc:new(),
   P2 = proc:new(),
   P3 = proc:new(),
   {ok, Conn1} = proc:exec(P1, {mero_pool, checkout, [?POOL, ?TIMELIMIT(1000)]}),
   {ok, Conn2} = proc:exec(P2, {mero_pool, checkout, [?POOL, ?TIMELIMIT(1000)]}),
+  mero_test_util:wait_for_pool_state(?POOL, 0, 2, 0, 0),
+
+  ct:log("Only on reject are new connections minted."),
+  {error, reject} = proc:exec(P3, {mero_pool, checkout, [?POOL, ?TIMELIMIT(1000)]}),
   mero_test_util:wait_for_pool_state(?POOL, 2, 4, 0, 0),
+
+  ct:log("Now we can take a new connection."),
   {ok, Conn3} = proc:exec(P3, {mero_pool, checkout, [?POOL, ?TIMELIMIT(1000)]}),
+  mero_test_util:wait_for_pool_state(?POOL, 1, 4, 0, 0),
 
   timer:sleep(500),
   ct:log("kill the server so no connection can be stablished from now on! ;)"),

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -44,22 +44,22 @@
 
 %% TODO: Uncomment these if you want to test agains a specific memcache server
 all() -> [
-%%          get_undefined_binary,
-%%          get_undefined_txt,
-%%          get_set_binary,
-%%          get_set_txt,
-%%          flush_binary,
-%%          flush_txt,
-%%          delete_binary,
-%%          delete_txt,
-%%          mget_binary,
-%%          mget_txt,
-%%          add_binary,
-%%          add_txt,
-%%          increment_binary,
-%%          increment_txt,
-%%          increment_binary_with_initial,
-%%          increment_txt_with_initial
+         %% get_undefined_binary,
+         %% get_undefined_txt,
+         %% get_set_binary,
+         %% get_set_txt,
+         %% flush_binary,
+         %% flush_txt,
+         %% delete_binary,
+         %% delete_txt,
+         %% mget_binary,
+         %% mget_txt,
+         %% add_binary,
+         %% add_txt,
+         %% increment_binary,
+         %% increment_txt,
+         %% increment_binary_with_initial,
+         %% increment_txt_with_initial
     ].
 
 
@@ -103,7 +103,6 @@ end_per_suite(_Conf) ->
 init_per_testcase(_Module, Conf) ->
     ct:log("state ~p", [mero:state()]),
     Keys = [key() || _  <- lists:seq(1, 4)],
-    dbg(),
     [{keys, Keys} | Conf].
 
 
@@ -329,16 +328,3 @@ add(Cluster, ClusterAlt, Keys) ->
 
 key() ->
     base64:encode(crypto:strong_rand_bytes(20)).
-
-%% Just for test purposes
-dbg() ->
-    dbg:tracer(),
-    dbg:p(all, c),
-    dbg:tpl(?MODULE,x),
-    dbg:tp(mero_cluster,x),
-    %dbg:tpl(mero_cluster_txt_localhost_1_0,x),
-    dbg:tp(mero,x),
-    dbg:tpl(mero_dummy_server, x),
-    dbg:tpl(mero_wrk_tcp_txt, x),
-    dbg:tpl(mero_conn, x),
-    ok.


### PR DESCRIPTION
This commit does two things. First, it now drops the number of failed
connections very slowly, instead of flattening it out on the first
successful connection. Second, we continue to use the background
creation of sockets but take into account potential jumps over the max
threshold.

Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>