### PR TITLE
Handle Max Connections and friends differently

### DIFF
--- a/src/mero_pool.erl
+++ b/src/mero_pool.erl
@@ -269,10 +269,10 @@ pool_loop(State, Parent, Deb) ->
 
 
 get_connection(#pool_st{free = Free} = State, From) when Free /= [] ->
-    maybe_spawn_connect(give(State, From));
+    give(State, From);
 get_connection(State, {Pid, Ref} = _From) ->
     safe_send(Pid, {Ref, {reject, State}}),
-    State.
+    maybe_spawn_connect(State).
 
 
 maybe_spawn_connect(#pool_st{

--- a/src/mero_pool.erl
+++ b/src/mero_pool.erl
@@ -227,12 +227,20 @@ pool_loop(State, Parent, Deb) ->
         connect_failed ->
             ?MODULE:pool_loop(connect_failed(State), Parent, Deb);
         connect ->
-            spawn_connect(State#pool_st.pool,
-                          State#pool_st.worker_module,
-                          State#pool_st.host,
-                          State#pool_st.port,
-                          State#pool_st.callback_info),
-            ?MODULE:pool_loop(State, Parent, Deb);
+            NumConnecting = State#pool_st.num_connecting,
+            Connected = State#pool_st.num_connected,
+            MaxConns = State#pool_st.max_connections,
+            case (NumConnecting + Connected) > MaxConns of
+                true ->
+                    ?MODULE:pool_loop(State#pool_st{num_connecting = NumConnecting - 1}, Parent, Deb);
+                false ->
+                    spawn_connect(State#pool_st.pool,
+                                  State#pool_st.worker_module,
+                                  State#pool_st.host,
+                                  State#pool_st.port,
+                                  State#pool_st.callback_info),
+                    ?MODULE:pool_loop(State, Parent, Deb)
+            end;
         {checkout, From} ->
             ?MODULE:pool_loop(get_connection(State, From), Parent, Deb);
         {checkin, Pid, Conn} ->
@@ -262,7 +270,6 @@ pool_loop(State, Parent, Deb) ->
 
 get_connection(#pool_st{free = Free} = State, From) when Free /= [] ->
     maybe_spawn_connect(give(State, From));
-
 get_connection(State, {Pid, Ref} = _From) ->
     safe_send(Pid, {Ref, {reject, State}}),
     State.
@@ -275,16 +282,19 @@ maybe_spawn_connect(#pool_st{
                        min_connections = MinConn,
                        num_connecting = Connecting,
                        num_failed_connecting = NumFailed,
-                       reconnect_wait_time = WaitTime,
                        worker_module = WrkModule,
                        callback_info = CallbackInfo,
+                       reconnect_wait_time = WaitTime,
                        pool = Pool,
                        host = Host,
                        port = Port} = State) ->
     %% Length could be big.. better to not have more than a few dozens of sockets
     %% May be worth to keep track of the length of the free in a counter.
-    MaxAllowed = MaxConn - (Connected + Connecting),
-    Needed = case MinConn - (length(Free) + Connecting) of
+    TotalSockets = Connected + Connecting,
+    IdleSockets  = length(Free) + Connecting,
+
+    MaxAllowed = MaxConn - TotalSockets,
+    Needed = case MinConn - IdleSockets of
                  MaxNeeded when MaxNeeded > MaxAllowed ->
                      MaxAllowed;
                  MaxNeeded ->
@@ -293,7 +303,7 @@ maybe_spawn_connect(#pool_st{
     if
         %% Need sockets and no failed connections are reported..
         %% we create new ones
-        (Needed > 0), NumFailed =< 1 ->
+        (Needed > 0), NumFailed < 1 ->
             spawn_connections(Pool, WrkModule, Host, Port, CallbackInfo, Needed),
             State#pool_st{num_connecting = Connecting + Needed};
 
@@ -301,7 +311,7 @@ maybe_spawn_connect(#pool_st{
         %% connection attempt has failed. Don't open more than
         %% one connection until an attempt has succeeded again.
         (Needed > 0), Connecting == 0 ->
-            reconnect_after_wait(WaitTime),
+            erlang:send_after(WaitTime, self(), connect),
             State#pool_st{num_connecting = Connecting + 1};
 
         %% We dont need sockets or we have failed connections
@@ -316,13 +326,21 @@ connect_success(#pool_st{free = Free,
                          num_connecting = NumConnecting,
                          num_failed_connecting = NumFailed} = State,
                 Conn) ->
+    NewNumFailed = case NumFailed - 1 of
+                       Neg when Neg < 0 ->
+                           0;
+                       Other ->
+                           Other
+                   end,
     NState = State#pool_st{free = [Conn|Free],
                            num_connected = Num + 1,
                            num_connecting = NumConnecting - 1,
-                           num_failed_connecting = 0},
-    case (NumFailed > 0) of
-        true -> maybe_spawn_connect(NState);
-        false -> NState
+                           num_failed_connecting = NewNumFailed},
+    case (NewNumFailed > 0) of
+        true ->
+            maybe_spawn_connect(NState);
+        false ->
+            NState
     end.
 
 
@@ -375,13 +393,9 @@ give(#pool_st{free = [Conn|Free],
     State#pool_st{busy = dict:store(Pid, {MRef, Conn}, Busy), free = Free}.
 
 
-reconnect_after_wait(WaitTime) ->
-    erlang:send_after(WaitTime, self(), connect).
-
-
-%% connect inmediately
 spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo) ->
-    spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo, 0).
+    MaxConnectionDelayTime = mero_conf:max_connection_delay_time(),
+    spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo, MaxConnectionDelayTime).
 
 spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo, SleepTime) ->
     spawn_link(fun() ->
@@ -397,7 +411,6 @@ spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo, SleepTime) ->
                end).
 
 
-%% Connect with delay
 spawn_connections(Pool, WrkModule, Host, Port, CallbackInfo, 1) ->
     spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo);
 spawn_connections(Pool, WrkModule, Host, Port, CallbackInfo, Number) when (Number > 0) ->

--- a/test/mero_SUITE.erl
+++ b/test/mero_SUITE.erl
@@ -85,7 +85,6 @@ init_per_testcase(_Module, Conf) ->
     [{pids, Pids} | Conf].
 
 end_per_testcase(_Module, Conf) ->
-    dbg:stop_clear(),
     {ok, Pids} = proplists:get_value(pids, Conf),
     mero_test_util:stop_servers(Pids),
     mero_dummy_server:reset_all_keys(),
@@ -129,7 +128,6 @@ delete(_Conf) ->
 
 set(_Conf) ->
     ct:log("state ~p", [mero:state()]),
-    dbg(),
     ?assertMatch(ok, mero:set(cluster, <<"11">>, <<"Adroll">>, 11111, 1000)),
     ?assertMatch({<<"11">>, <<"Adroll">>}, mero:get(cluster, <<"11">>)),
 
@@ -231,7 +229,6 @@ increment(_Conf) ->
 
 add(_Conf) ->
     ?assertMatch(ok, mero:add(cluster, <<"11">>, <<"Adroll">>, 11111, 1000)),
-    dbg(),
     ct:log("First not stored"),
     ?assertMatch({error, not_stored}, mero:add(cluster, <<"11">>, <<"Adroll2">>, 111111, 1000)),
     ct:log("Second not stored"),
@@ -254,15 +251,3 @@ m() ->
 
 key() ->
     base64:encode(crypto:strong_rand_bytes(20)).
-
-%% Just for test purposes
-dbg() ->
-    dbg:tracer(),
-    dbg:p(all, c),
-    %dbg:tp(mero_cluster,x),
-    %dbg:tpl(mero_cluster_localhost_1_0,x),
-    %dbg:tp(mero_pool,x),
-    dbg:tpl(mero_dummy_server, x),
-    dbg:tpl(mero_wrk_tcp_txt, x),
-    dbg:tpl(mero_conn, x),
-    ok.

--- a/test/mero_cluster_SUITE.erl
+++ b/test/mero_cluster_SUITE.erl
@@ -60,7 +60,7 @@ init_per_testcase(_, Conf) ->
 
 
 end_per_testcase(_, _Conf) ->
-    dbg:stop_clear().
+    ok.
 
 %%%=============================================================================
 %%% Tests
@@ -170,7 +170,6 @@ group_by_shards(_Conf) ->
                 {pool_worker_module, mero_wrk_tcp_txt}]}],
     mero_cluster:load_clusters(Config),
     ?assertMatch([], mero_cluster:group_by_shards(cluster, [])),
-    dbg(),
     ?assertMatch([
         {0, [<<"6">>, <<"13">>, <<"14">>, <<"15">>, <<"17">>]},
         {1, [<<"1">>,<<"2">>,<<"3">>,<<"4">>,<<"5">>,<<"7">>,
@@ -184,10 +183,3 @@ group_by_shards(_Conf) ->
             <<"14">>, <<"15">>, <<"16">>,
             <<"17">>, <<"18">>, <<"19">>])),
     ok.
-
-dbg() ->
-    dbg:tracer(),
-    dbg:p(all,c),
-    dbg:tpl(mero_cluster,x),
-    ok.
-

--- a/test/mero_pool_SUITE.erl
+++ b/test/mero_pool_SUITE.erl
@@ -77,7 +77,6 @@ init_per_testcase(_, Conf) ->
 
 
 end_per_testcase(_, _Conf) ->
-  dbg:stop_clear(),
   application:stop(mero).
 
 %%%=============================================================================
@@ -229,7 +228,7 @@ checkout_checkin_limits(_) ->
     proc:exec(proc:new(), {mero_pool, checkout, [?POOL, ?TIMELIMIT(1000)]})),
   mero_test_util:wait_for_pool_state(?POOL, 1, 4, 0, 0),
 
-  ct:log("The first one is on use so the second one should be stablished soon"),
+  ct:log("The first one is on use so the second one should be established soon"),
   ok = mero_pool:checkin(Conn1),
   mero_test_util:wait_for_pool_state(?POOL, 2, 4, 0, 0),
 
@@ -306,12 +305,3 @@ checkout_timeout(_) ->
 %%%=============================================================================
 %%% Helper functions
 %%%=============================================================================
-
-dbg() ->
-  dbg:tracer(),
-  dbg:p(all,c),
-  dbg:tpl(mero_sup,x),
-  dbg:tpl(mero_pool,x),
-  dbg:tpl(mero,x),
-  dbg:tpl(mero_wrk,x),
-  ok.

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -44,22 +44,22 @@
 
 %% TODO: Uncomment these if you want to test agains a specific memcache server
 all() -> [
-%%          get_undefined_binary,
-%%          get_undefined_txt,
-%%          get_set_binary,
-%%          get_set_txt,
-%%          flush_binary,
-%%          flush_txt,
-%%          delete_binary,
-%%          delete_txt,
-%%          mget_binary,
-%%          mget_txt,
-%%          add_binary,
-%%          add_txt,
-%%          increment_binary,
-%%          increment_txt,
-%%          increment_binary_with_initial,
-%%          increment_txt_with_initial
+         %% get_undefined_binary,
+         %% get_undefined_txt,
+         %% get_set_binary,
+         %% get_set_txt,
+         %% flush_binary,
+         %% flush_txt,
+         %% delete_binary,
+         %% delete_txt,
+         %% mget_binary,
+         %% mget_txt,
+         %% add_binary,
+         %% add_txt,
+         %% increment_binary,
+         %% increment_txt,
+         %% increment_binary_with_initial,
+         %% increment_txt_with_initial
     ].
 
 
@@ -103,7 +103,6 @@ end_per_suite(_Conf) ->
 init_per_testcase(_Module, Conf) ->
     ct:log("state ~p", [mero:state()]),
     Keys = [key() || _  <- lists:seq(1, 4)],
-    dbg(),
     [{keys, Keys} | Conf].
 
 
@@ -329,16 +328,3 @@ add(Cluster, ClusterAlt, Keys) ->
 
 key() ->
     base64:encode(crypto:strong_rand_bytes(20)).
-
-%% Just for test purposes
-dbg() ->
-    dbg:tracer(),
-    dbg:p(all, c),
-    dbg:tpl(?MODULE,x),
-    dbg:tp(mero_cluster,x),
-    %dbg:tpl(mero_cluster_txt_localhost_1_0,x),
-    dbg:tp(mero,x),
-    dbg:tpl(mero_dummy_server, x),
-    dbg:tpl(mero_wrk_tcp_txt, x),
-    dbg:tpl(mero_conn, x),
-    ok.


### PR DESCRIPTION
These commits address observed behaviour in high-load production environments where mero will allocate a tremendous amount of TCP connections against a memcache server. This happens when the server has a legitimate amount of traffic against it, causing new connections to be spawned aggressively, interacting poorly with the results from failed connections. 

Please see individual commits for details. 