### PR TITLE
Implement delete which reuses the same socket.

### DIFF
--- a/include/mero.hrl
+++ b/include/mero.hrl
@@ -37,6 +37,7 @@
 -define(MEMCACHE_SET, 16#01).
 -define(MEMCACHE_ADD, 16#02).
 -define(MEMCACHE_DELETE, 16#04).
+-define(MEMCACHE_DELETEQ, 16#14).
 -define(MEMCACHE_FLUSH_ALL, 16#08).
 
 %%% If a connection attempt fails, or a connection is broken

--- a/src/mero.erl
+++ b/src/mero.erl
@@ -40,6 +40,7 @@
          get/2,
          get/3,
          delete/3,
+         mdelete/3,
          mget/3,
          set/5,
          add/5,
@@ -145,6 +146,10 @@ increment_counter(ClusterName, Key, Value, Initial, ExpTime, Retries, Timeout)
 delete(ClusterName, Key, Timeout) when is_binary(Key), is_atom(ClusterName) ->
     mero_conn:delete(ClusterName, Key, Timeout).
 
+-spec mdelete(ClusterName :: atom(), Keys :: [binary()], Timeout :: integer()) ->
+    ok | {error, Reason :: term()}.
+mdelete(ClusterName, Keys, Timeout) when is_list(Keys), is_atom(ClusterName) ->
+    mero_conn:mdelete(ClusterName, Keys, Timeout).
 
 %% The response is a list of all the individual requests, one per shard
 -spec flush_all(ClusterName :: atom()) ->

--- a/src/mero_conn.erl
+++ b/src/mero_conn.erl
@@ -34,6 +34,7 @@
          get/3,
          set/5,
          delete/3,
+         mdelete/3,
          add/5,
          flush_all/2
         ]).
@@ -67,6 +68,12 @@ delete(Name, Key, Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     PoolName = mero_cluster:server(Name, Key),
     pool_execute(PoolName, delete, [Key, TimeLimit], TimeLimit).
+
+
+mdelete(Name, Keys, Timeout) ->
+    TimeLimit = mero_conf:add_now(Timeout),
+    PoolName = mero_cluster:server(Name, Keys),
+    pool_execute(PoolName, mdelete, [Keys, TimeLimit], TimeLimit).
 
 
 add(Name, Key, Value, ExpTime, Timeout) ->

--- a/src/mero_conn.erl
+++ b/src/mero_conn.erl
@@ -79,7 +79,8 @@ mdelete(Name, Keys, Timeout) ->
     %% Jazz for my present experimental purposes.
     %%
     %% -blt
-    lists:foreach(fun ({PoolName, Ks}) ->
+    lists:foreach(fun ({ShardIdentifier, Ks}) ->
+                          PoolName = mero_cluster:random_pool_of_shard(Name, ShardIdentifier),
                           pool_execute(PoolName, mdelete, [Ks, TimeLimit], TimeLimit)
                   end, KeysGroupedByShards).
 

--- a/src/mero_util.erl
+++ b/src/mero_util.erl
@@ -1,6 +1,6 @@
 -module(mero_util).
 
--export([foreach/2]).
+-export([foreach/2, to_int/1, to_bin/1]).
 
 %%%===================================================================
 %%% API
@@ -11,6 +11,19 @@
 foreach(Fun, L) ->
     foreach(continue, Fun, L).
 
+to_int(Value) when is_integer(Value) ->
+    Value;
+to_int(Value) when is_list(Value) ->
+    list_to_integer(Value);
+to_int(Value) when is_binary(Value) ->
+    to_int(binary_to_list(Value)).
+
+to_bin(Value) when is_binary(Value) ->
+    Value;
+to_bin(Value) when is_integer(Value) ->
+    to_bin(integer_to_list(Value));
+to_bin(Value) when is_list(Value) ->
+    list_to_binary(Value).
 
 %%%===================================================================
 %%% Internal Functions

--- a/src/mero_util.erl
+++ b/src/mero_util.erl
@@ -1,0 +1,24 @@
+-module(mero_util).
+
+-export([foreach/2]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec foreach(fun((Elem :: term()) -> {break, term()} | continue),
+              list()) -> term().
+foreach(Fun, L) ->
+    foreach(continue, Fun, L).
+
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+foreach({break, Reason}, _Fun, _L) ->
+    Reason;
+foreach(continue, _Fun, []) ->
+    ok;
+foreach(continue, Fun, [H|Rest]) ->
+    foreach(Fun(H), Fun, Rest).

--- a/src/mero_wrk_tcp_txt.erl
+++ b/src/mero_wrk_tcp_txt.erl
@@ -109,6 +109,19 @@ transaction(Client, delete, [Key,  TimeLimit]) ->
             {error, Reason}
     end;
 
+transaction(Client, mdelete, [Keys,  TimeLimit]) ->
+    lists:foreach(fun(Key) ->
+                          case send_receive(Client, {?MEMCACHE_DELETE, {Key}}, TimeLimit) of
+                              {ok, deleted} ->
+                                  {Client, ok};
+                              {error, not_found} ->
+                                  {Client, {error, not_found}};
+                              {error, Reason} ->
+                                  {error, Reason}
+                          end
+                  end, Keys),
+    {Client, ok};
+
 transaction(Client, add, [Key, Value, ExpTime, TimeLimit]) ->
     case send_receive(Client, {?MEMCACHE_ADD, {Key, Value, ExpTime}}, TimeLimit) of
         {ok, stored} ->

--- a/test/mero_SUITE.erl
+++ b/test/mero_SUITE.erl
@@ -43,9 +43,8 @@
 %%%=============================================================================
 
 all() -> [
+          {group, binary_protocol},
           {group, text_protocol}
-          %% temporarily disabled
-          %% {group, binary_protocol}
          ].
 
 groups() ->
@@ -197,11 +196,13 @@ set(_Conf) ->
     ?assertMatch(ok, mero:set(cluster, <<"12">>, <<"Adroll2">>, 11111, 1000)),
     ?assertMatch({<<"12">>, <<"Adroll2">>}, mero:get(cluster, <<"12">>)),
 
-    [{<<"12">>, <<"Adroll2">>},
-     {<<"11">>, <<"Adroll">>}] = mero:mget(cluster, [<<"11">>, <<"12">>], 5000),
+    Resp0 = mero:mget(cluster, [<<"11">>, <<"12">>], 5000),
+    [{<<"11">>, <<"Adroll">>},
+     {<<"12">>, <<"Adroll2">>}] = lists:sort(Resp0),
 
+    Resp1 = mero:mget(cluster2, [<<"11">>, <<"12">>], 5000),
     [{<<"11">>, undefined},
-     {<<"12">>, undefined}] = mero:mget(cluster2, [<<"11">>, <<"12">>], 5000),
+     {<<"12">>, undefined}] = lists:sort(Resp1),
 
     ok.
 
@@ -219,14 +220,14 @@ multiget_undefineds(_Conf) ->
 
     %% 13, 14 and 15 will go to the same server
     %% 11, 12 and 16 to a different one
-    [{<<"13">>, undefined},
-     {<<"14">>, undefined},
-        {<<"15">>, undefined},
+    Resp = mero:mget(cluster, [<<"11">>,<<"12">>,<<"13">>,<<"14">>,<<"15">>,<<"16">>], 1000),
 
-        {<<"11">>, undefined},
-        {<<"12">>, undefined},
-        {<<"16">>, undefined}] = mero:mget(cluster,
-        [<<"11">>,<<"12">>,<<"13">>,<<"14">>,<<"15">>,<<"16">>], 1000).
+    [{<<"11">>, undefined},
+     {<<"12">>, undefined},
+     {<<"13">>, undefined},
+     {<<"14">>, undefined},
+     {<<"15">>, undefined},
+     {<<"16">>, undefined}] = lists:sort(Resp).
 
 
 multiget_defineds(_Conf) ->
@@ -299,7 +300,7 @@ add(_Conf) ->
     ?assertMatch({<<"11">>, <<"Adroll">>}, mero:get(cluster, <<"11">>)),
 
     % ?assertMatch({<<"11">>, <<"Adroll">>}, mero:get(cluster, <<"11">>)),
-    oik.
+    ok.
 m() ->
     ?assertMatch(ok,  mero:delete(cluster, <<"11">>, 1000)),
     ?assertMatch({<<"11">>, undefined}, mero:get(cluster, <<"11">>)),

--- a/test/mero_SUITE.erl
+++ b/test/mero_SUITE.erl
@@ -126,6 +126,8 @@ init_per_testcase(_Module, Conf) ->
     application:load(mero),
     ClusterConfig = ?config(cluster_config, Conf),
     Pids = mero_test_util:start_server(ClusterConfig, 1, 1, 30000, 90000),
+    mero_conf:timeout_write(1000),
+    mero_conf:timeout_read(1000),
     [{pids, Pids} | Conf].
 
 end_per_testcase(_Module, Conf) ->
@@ -142,16 +144,18 @@ end_per_testcase(_Module, Conf) ->
 undefined_counter(_Conf) ->
     Key = key(),
     ct:log("state ~p", [mero:state()]),
-    ?assertMatch({Key, undefined}, mero:get(cluster, Key)),
-    ?assertMatch({Key, undefined}, mero:get(cluster, Key)),
-    ?assertMatch({Key, undefined}, mero:get(cluster2, Key)),
-    ?assertMatch({Key, undefined}, mero:get(cluster2, Key)),
+    ?assertMatch({Key, undefined}, mero:get(cluster, Key, 1000)),
+    ?assertMatch({Key, undefined}, mero:get(cluster, Key, 1000)),
+    ?assertMatch({Key, undefined}, mero:get(cluster2, Key, 1000)),
+    ?assertMatch({Key, undefined}, mero:get(cluster2, Key, 1000)),
     ok.
 
 
 increase_counter(_Conf) ->
     Key = key(),
     ct:log("state ~p", [mero:state()]),
+    ct:log("READ ~p", [mero_conf:timeout_read()]),
+    ct:log("WRITE ~p", [mero_conf:timeout_write()]),
     ?assertMatch({ok, 1}, mero:increment_counter(cluster, Key)),
     ?assertMatch({ok, 2}, mero:increment_counter(cluster, Key)),
     ?assertMatch({ok, 1}, mero:increment_counter(cluster2, Key)),
@@ -211,9 +215,9 @@ get_undefineds(_Conf) ->
     Key2 = key(),
     Key3 = key(),
 
-    {Key, undefined} = mero:get(cluster, Key),
-    {Key2, undefined} = mero:get(cluster, Key2),
-    {Key3, undefined} = mero:get(cluster, Key3).
+    {Key, undefined} = mero:get(cluster, Key, 1000),
+    {Key2, undefined} = mero:get(cluster, Key2, 1000),
+    {Key3, undefined} = mero:get(cluster, Key3, 1000).
 
 multiget_undefineds(_Conf) ->
    [] = mero:mget(cluster, [], 1000),

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -51,8 +51,8 @@ all() -> [
          %% flush_binary,
          %% flush_txt,
          %% delete_binary,
-         %% mdelete_binary,
-         %% mdelete_txt,
+         mdelete_binary,
+         mdelete_txt
          %% delete_txt,
          %% mget_binary,
          %% mget_txt,

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -51,8 +51,8 @@ all() -> [
          %% flush_binary,
          %% flush_txt,
          %% delete_binary,
-         mdelete_binary,
-         mdelete_txt
+         %% mdelete_binary,
+         %% mdelete_txt,
          %% delete_txt,
          %% mget_binary,
          %% mget_txt,

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -44,26 +44,6 @@
 
 %% TODO: Uncomment these if you want to test agains a specific memcache server
 all() -> [
-<<<<<<< HEAD
-%%          get_undefined_binary,
-%%          get_undefined_txt,
-%%          get_set_binary,
-%%          get_set_txt,
-%%          flush_binary,
-%%          flush_txt,
-%%          delete_binary,
-%%          mdelete_binary,
-%%          mdelete_txt,
-%%          delete_txt,
-%%          mget_binary,
-%%          mget_txt,
-%%          add_binary,
-%%          add_txt,
-%%          increment_binary,
-%%          increment_txt,
-%%          increment_binary_with_initial,
-%%          increment_txt_with_initial
-=======
          %% get_undefined_binary,
          %% get_undefined_txt,
          %% get_set_binary,
@@ -71,6 +51,8 @@ all() -> [
          %% flush_binary,
          %% flush_txt,
          %% delete_binary,
+         %% mdelete_binary,
+         %% mdelete_txt,
          %% delete_txt,
          %% mget_binary,
          %% mget_txt,
@@ -80,7 +62,6 @@ all() -> [
          %% increment_txt,
          %% increment_binary_with_initial,
          %% increment_txt_with_initial
->>>>>>> master
     ].
 
 

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -51,6 +51,8 @@ all() -> [
 %%          flush_binary,
 %%          flush_txt,
 %%          delete_binary,
+%%          mdelete_binary,
+%%          mdelete_txt,
 %%          delete_txt,
 %%          mget_binary,
 %%          mget_txt,
@@ -148,11 +150,18 @@ delete_binary(Conf) ->
     Keys = keys(Conf),
     delete(cluster_binary, Keys).
 
+mdelete_binary(Conf) ->
+    Keys = keys(Conf),
+    mdelete(cluster_binary, Keys).
+
 
 delete_txt(Conf) ->
     Keys = keys(Conf),
     delete(cluster_txt, Keys).
 
+mdelete_txt(Conf) ->
+    Keys = keys(Conf),
+    mdelete(cluster_txt, Keys).
 
 mget_binary(Conf) ->
     Keys = keys(Conf),
@@ -243,6 +252,19 @@ delete(Cluster, Keys) ->
 
     ct:log("Delete ! ~n", []),
     [ok = mero:delete(Cluster, Key, 1000) || Key <- Keys],
+
+    ct:log("Checking empty keys ~n"),
+    [{Key, undefined} = mero:get(Cluster, Key) || Key <- Keys].
+
+
+mdelete(Cluster, Keys) ->
+    ct:log("Check set to adroll ~n"),
+    ct:log("state ~p", [mero:state()]),
+    [ok = mero:set(Cluster, Key, <<"Adroll">>, 11111, 1000)
+        || Key <- Keys],
+
+    ct:log("Delete ! ~n", []),
+    ok = mero:mdelete(Cluster, Keys, 1000),
 
     ct:log("Checking empty keys ~n"),
     [{Key, undefined} = mero:get(Cluster, Key) || Key <- Keys].


### PR DESCRIPTION
Memcache offers no proper multi-delete. Previously, a client doing
multiple deletes was likely to issue these over multiple sockets, a
waste if you have a lot of deletes to push out in one go.

This commit introduces 'mdelete/3' which will re-use the same socket
for a bunch of deletes. When possible, DELETEQ is used. I have not
adapted the dummy server to handle binary tests but have confirmed
proper functioning against a real memcache server.

Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>