### PR TITLE
Misc adjustments

### DIFF
--- a/include/mero.hrl
+++ b/include/mero.hrl
@@ -41,6 +41,16 @@
 -define(MEMCACHE_DELETEQ, 16#14).
 -define(MEMCACHE_FLUSH_ALL, 16#08).
 
+-define(NO_ERROR,          16#0000).
+-define(NOT_FOUND,         16#0001).
+-define(KEY_EXISTS,        16#0002).
+-define(VALUE_TOO_LARGE,   16#0003).
+-define(INVALID_ARGUMENTS, 16#0004).
+-define(NOT_STORED,        16#0005).
+-define(NON_NUMERIC_INCR,  16#0006).
+-define(UNKNOWN_COMMAND,   16#0081).
+-define(OOM,               16#0082).
+
 %%% If a connection attempt fails, or a connection is broken
 -define(RECONNECT_WAIT_TIME, 200).
 

--- a/src/mero_cluster.erl
+++ b/src/mero_cluster.erl
@@ -217,8 +217,7 @@ shard_identifier(Name, Key) ->
 -spec random_integer(Max :: integer()) ->
     integer().
 random_integer(Max) when Max > 0 ->
-    random:seed(os:timestamp()),
-    random:uniform(Max) - 1.
+    rand:uniform(Max) - 1.
 
 
 

--- a/src/mero_conn.erl
+++ b/src/mero_conn.erl
@@ -78,6 +78,16 @@ set(Name, Key, Value, ExpTime, Timeout, CAS) ->
     pool_execute(PoolName, set, [Key, Value, ExpTime, TimeLimit, CAS], TimeLimit).
 
 
+get(Name, [Key], Timeout) ->
+    TimeLimit = mero_conf:add_now(Timeout),
+    PoolName = mero_cluster:server(Name, Key),
+    case pool_execute(PoolName, get, [Key, TimeLimit], TimeLimit) of
+        {error, Reason} ->
+            {error, [Reason], []};
+        Value ->
+            [Value]
+    end;
+
 get(Name, Keys, Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     KeysGroupedByShards = mero_cluster:group_by_shards(Name, Keys),

--- a/src/mero_conn.erl
+++ b/src/mero_conn.erl
@@ -179,7 +179,7 @@ async_by_shard(Name, KeysGroupedByShards, TimeLimit,
                     mero_pool:checkin_closed(Conn),
                     {ProcessedIn, [Reason | ErrorsIn]};
                 {Client, {error, Reason}} ->
-                    mero_pool:checkin_closed(Client),
+                    mero_pool:checkin(Client),
                     {ProcessedIn, [Reason | ErrorsIn]};
                 {Client, Responses} when is_list(Responses) ->
                     mero_pool:checkin(Client),

--- a/src/mero_pool.erl
+++ b/src/mero_pool.erl
@@ -393,8 +393,7 @@ spawn_connect(Pool, WrkModule, Host, Port, CallbackInfo, SleepTime) ->
                        case (SleepTime > 0) of
                            true ->
                                %% Wait before reconnect
-                               random:seed(os:timestamp()),
-                               timer:sleep(random:uniform(SleepTime));
+                               timer:sleep(rand:uniform(SleepTime));
                            false ->
                                ignore
                        end,

--- a/src/mero_wrk_tcp_binary.erl
+++ b/src/mero_wrk_tcp_binary.erl
@@ -300,23 +300,23 @@ receive_response(Client, Op, TimeLimit) ->
             case recv_bytes(Client, BodySize, TimeLimit) of
                 <<_Extras:ExtrasSize/binary, Key:KeySize/binary, Value/binary>> ->
                     case Status of
-                        16#0001 ->
-                            #mero_item{key = Key, cas = cas_value(CAS)};
-                        16#0000 ->
+                        ?NO_ERROR ->
                             #mero_item{key = Key, value = Value, cas = cas_value(CAS)};
-                        16#0002 ->
+                        ?NOT_FOUND ->
+                            #mero_item{key = Key, cas = cas_value(CAS)};
+                        ?KEY_EXISTS ->
                             {error, already_exists};
-                        16#0003 ->
+                        ?VALUE_TOO_LARGE ->
                             {error, value_too_large};
-                        16#0004 ->
+                        ?INVALID_ARGUMENTS ->
                             {error, invalid_arguments};
-                        16#0005 ->
+                        ?NOT_STORED ->
                             {error, not_stored};
-                        16#0006 ->
+                        ?NON_NUMERIC_INCR ->
                             {error, incr_decr_on_non_numeric_value};
-                        16#0081 ->
+                        ?UNKNOWN_COMMAND ->
                             {error, unknown_command};
-                        16#0082 ->
+                        ?OOM ->
                             {error, out_of_memory};
                         Status ->
                             throw({failed, {response_status, Status}})
@@ -440,6 +440,6 @@ receive_response(Client, TimeLimit, Keys, Acc) ->
 async_blank_response(_Client, _Keys, _TimeLimit) ->
     {ok, [ok]}.
 
-filter_by_status(16#0000, _Op, Key, ValueReceived)  -> {Key, ValueReceived};
-filter_by_status(16#0001, _Op, Key, _ValueReceived) -> {Key, undefined};
+filter_by_status(?NO_ERROR,  _Op, Key, ValueReceived)  -> {Key, ValueReceived};
+filter_by_status(?NOT_FOUND, _Op, Key, _ValueReceived) -> {Key, undefined};
 filter_by_status(Status, _Op, _Key, _ValueReceived) -> throw({failed, {response_status, Status}}).

--- a/src/mero_wrk_tcp_txt.erl
+++ b/src/mero_wrk_tcp_txt.erl
@@ -132,6 +132,16 @@ transaction(Client, add, [Key, Value, ExpTime, TimeLimit]) ->
             {error, Reason}
     end;
 
+transaction(Client, get, [Key, TimeLimit]) ->
+    case send_receive(Client, {?MEMCACHE_GET, {[Key]}}, TimeLimit) of
+        {ok, [Found]} ->
+            {Client, Found};
+        {ok, []} ->
+            {Client, #mero_item{key = Key}};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+
 transaction(Client, set, [Key, Value, ExpTime, TimeLimit, CAS]) ->
     case send_receive(Client, {?MEMCACHE_SET, {Key, Value, ExpTime, CAS}}, TimeLimit) of
         {ok, stored} ->

--- a/test/mero_dummy_server.erl
+++ b/test/mero_dummy_server.erl
@@ -245,7 +245,7 @@ canned_responses(text, _Key, _Op, noop)           -> [];
 canned_responses(binary, _Key, Op, not_found) ->
     ExtrasOut = <<>>,
     ExtrasSizeOut = size(ExtrasOut),
-    Status = 1,
+    Status = ?NOT_FOUND,
     BodyOut = <<>>,
     BodySizeOut = size(BodyOut),
     KeySize = 0,
@@ -256,7 +256,7 @@ canned_responses(binary, _Key, Op, not_found) ->
 canned_responses(binary, _Key, Op, not_stored) ->
     ExtrasOut = <<>>,
     ExtrasSizeOut = size(ExtrasOut),
-    Status = 5,
+    Status = ?NOT_STORED,
     BodyOut = <<>>,
     BodySizeOut = size(BodyOut),
     KeySize = 0,
@@ -267,7 +267,7 @@ canned_responses(binary, _Key, Op, not_stored) ->
 canned_responses(binary, _Key, Op, stored) ->
     ExtrasOut = <<>>,
     ExtrasSizeOut = size(ExtrasOut),
-    Status = 0,
+    Status = ?NO_ERROR,
     BodyOut = <<>>,
     BodySizeOut = size(BodyOut),
     KeySize = 0,
@@ -278,7 +278,7 @@ canned_responses(binary, _Key, Op, stored) ->
 canned_responses(binary, _Key, Op, deleted) -> %% same as stored, intentionally
     ExtrasOut = <<>>,
     ExtrasSizeOut = size(ExtrasOut),
-    Status = 0,
+    Status = ?NO_ERROR,
     BodyOut = <<>>,
     BodySizeOut = size(BodyOut),
     KeySize = 0,
@@ -289,7 +289,7 @@ canned_responses(binary, _Key, Op, deleted) -> %% same as stored, intentionally
 canned_responses(binary, _Key, ?MEMCACHE_INCREMENT, {incr, I}) ->
     ExtrasOut = <<>>,
     ExtrasSizeOut = size(ExtrasOut),
-    Status = 0,
+    Status = ?NO_ERROR,
     BodyOut = <<ExtrasOut/binary, I:64/integer>>,
     BodySizeOut = size(BodyOut),
     KeySize = 0,
@@ -300,7 +300,7 @@ canned_responses(binary, _Key, ?MEMCACHE_INCREMENT, {incr, I}) ->
 canned_responses(binary, _Key, Op, already_exists) ->
     ExtrasOut = <<>>,
     ExtrasSizeOut = size(ExtrasOut),
-    Status = 16#0002,
+    Status = ?KEY_EXISTS,
     BodyOut = <<>>,
     BodySizeOut = size(BodyOut),
     KeySize = 0,
@@ -337,8 +337,8 @@ binary_response_get_keys(_Port, [], Acc, _WithCas) ->
     Acc;
 binary_response_get_keys(Port, [{Op, Key} | Keys], Acc, WithCas) ->
     {Status, Value, CAS} =  case get_key(Port, Key) of
-                                undefined -> {1, <<>>, undefined};
-                                {Val, StoredCAS} -> {0, Val, StoredCAS}
+                                undefined -> {?NOT_FOUND, <<>>, undefined};
+                                {Val, StoredCAS} -> {?NO_ERROR, Val, StoredCAS}
                             end,
     LValue = mero_util:to_bin(Value),
     ExtrasOut = <<>>,


### PR DESCRIPTION
- use sync get when getting a single key
- use `#async_op{}` record instead of list for async op specs
- don't check in a connection as closed without closing it after non-fatal error in async op
- `rand` instead of `random`
- macros for response codes