### PR TITLE
fix bug in binary mget response

### DIFF
--- a/src/mero_wrk_tcp_binary.erl
+++ b/src/mero_wrk_tcp_binary.erl
@@ -428,7 +428,7 @@ receive_response(Client, TimeLimit, Keys, Acc) ->
                             receive_response(Client, TimeLimit, NKeys, Responses);
                         %% This was the last one!
                         ?MEMCACHE_GETK ->
-                            Responses ++ [{KeyIn, undefined} || KeyIn <- NKeys]
+                            Responses ++ [#mero_item{key = KeyIn} || KeyIn <- NKeys]
                     end;
                 Data ->
                     throw({failed, {unexpected_body, Data}})

--- a/test/mero_test_with_local_memcached_SUITE.erl
+++ b/test/mero_test_with_local_memcached_SUITE.erl
@@ -66,6 +66,7 @@ all() -> [
          %% mincrement_txt,
          %% cas_binary,
          %% cas_txt
+         %% mgets_binary
     ].
 
 
@@ -224,6 +225,10 @@ cas_txt(Conf) ->
 cas_binary(Conf) ->
     Keys = keys(Conf),
     cas(cluster_binary, cluster_txt, Keys).
+
+mgets_binary(Conf) ->
+    Keys = keys(Conf),
+    mgets(cluster_binary, cluster_txt, Keys).
 
 
 %%%=============================================================================
@@ -392,6 +397,14 @@ cas(Cluster, ClusterAlt, Keys) ->
          ?assertNotEqual(CAS, NCAS)
      end
      || Key <- Keys].
+
+
+%% our test server doesn't emulate a real memcached server with 100% accuracy.
+mgets(Cluster, _ClusterAlt, Keys) ->
+    Expected = lists:keysort(1, [{Key, undefined, undefined}
+                                 || Key <- Keys]),
+    ?assertEqual(Expected, lists:keysort(1, mero:mgets(Cluster, Keys, 1000))).
+
 
 
 %%%=============================================================================


### PR DESCRIPTION
Binary worker mget response wasn't updated with the introduction of `#mero_item{}` record, so not all original keys were returned when absent from cache in binary worker's mget response.