### PR TITLE
Allow custom clustering key

### DIFF
--- a/src/mero_conn.erl
+++ b/src/mero_conn.erl
@@ -56,12 +56,12 @@
 increment_counter(Name, Key, Value, Initial, ExpTime, Retries, Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     PoolName = mero_cluster:server(Name, Key),
-    increment_counter_timelimit(PoolName, Key, Value, Initial, ExpTime, Retries, TimeLimit).
+    increment_counter_timelimit(PoolName, mero:storage_key(Key), Value, Initial, ExpTime, Retries, TimeLimit).
 
 mincrement_counter(Name, Keys, Value, Initial, ExpTime, _Retries, Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     KeysGroupedByShards = mero_cluster:group_by_shards(Name, Keys),
-    Payload = [{Shard, [{K, Value, Initial, ExpTime} || K <- Ks]} || {Shard, Ks} <- KeysGroupedByShards],
+    Payload = [{Shard, [{mero:storage_key(K), Value, Initial, ExpTime} || K <- Ks]} || {Shard, Ks} <- KeysGroupedByShards],
     case async_by_shard(Name, Payload, TimeLimit,
                         #async_op{op = async_increment,
                                   op_error = async_increment_error,
@@ -75,7 +75,7 @@ mincrement_counter(Name, Keys, Value, Initial, ExpTime, _Retries, Timeout) ->
 set(Name, Key, Value, ExpTime, Timeout, CAS) ->
     TimeLimit = mero_conf:add_now(Timeout),
     PoolName = mero_cluster:server(Name, Key),
-    pool_execute(PoolName, set, [Key, Value, ExpTime, TimeLimit, CAS], TimeLimit).
+    pool_execute(PoolName, set, [mero:storage_key(Key), Value, ExpTime, TimeLimit, CAS], TimeLimit).
 
 
 mset(Name, KVECs, Timeout) ->
@@ -90,7 +90,7 @@ madd(Name, KVEs, Timeout) ->
 get(Name, [Key], Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     PoolName = mero_cluster:server(Name, Key),
-    case pool_execute(PoolName, get, [Key, TimeLimit], TimeLimit) of
+    case pool_execute(PoolName, get, [mero:storage_key(Key), TimeLimit], TimeLimit) of
         {error, Reason} ->
             {error, [Reason], []};
         Value ->
@@ -110,7 +110,7 @@ get(Name, Keys, Timeout) ->
 delete(Name, Key, Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     PoolName = mero_cluster:server(Name, Key),
-    pool_execute(PoolName, delete, [Key, TimeLimit], TimeLimit).
+    pool_execute(PoolName, delete, [mero:storage_key(Key), TimeLimit], TimeLimit).
 
 
 mdelete(Name, Keys, Timeout) ->
@@ -126,7 +126,7 @@ mdelete(Name, Keys, Timeout) ->
 add(Name, Key, Value, ExpTime, Timeout) ->
     TimeLimit = mero_conf:add_now(Timeout),
     PoolName = mero_cluster:server(Name, Key),
-    pool_execute(PoolName, add, [Key, Value, ExpTime, TimeLimit], TimeLimit).
+    pool_execute(PoolName, add, [mero:storage_key(Key), Value, ExpTime, TimeLimit], TimeLimit).
 
 
 flush_all(Name, Timeout) ->


### PR DESCRIPTION
So far, mero used as "clustering key" (i.e: the key used to determine in which memcached node store the data) the same than the storage key (i.e: the key used to store/retrival the data from the specific memcache node).

Sometimes, it is useful to be able to specify a custom clustering key.
In this way, you have a large memcached cluster,  and several cached items with keys K1,K2,..KN ,  all related to the same higher-level object O1.,  you can mandate that all those K1...KN use the same
Clustering Key O1.   By doing so, all related keys will be stored on the same memcached instance,  and one can take advantage of pipelining when retrieving them all.   Otherwise, all these related keys will be spread across the cluster, requiring separate GETs to each memcached instance.

For implementing this,  all API calls that expected a Key :: binary() now accept a mero_key().

```
    mero_key :: {ClusteringKey :: binary(),  Key :: binary()} | Key :: binary()
```

If a clustering key is not specified, it is assumed to be {Key, Key}, same behaviour than before this patch.