### PR TITLE
[RTI-2920] Allow the project to be compiled using old rebar

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -42,7 +42,7 @@
         ]
       },
       #{dirs => ["."],
-        filter => "rebar.config",
+        filter => "*rebar.config",
         ruleset => rebar_config,
         rules => [
             %% Elixir deps use git@...

--- a/old.rebar.config
+++ b/old.rebar.config
@@ -1,0 +1,19 @@
+{erl_opts, [
+    warn_unused_vars,
+    warn_export_all,
+    warn_shadow_vars,
+    warn_unused_import,
+    warn_unused_function,
+    warn_bif_clash,
+    warn_unused_record,
+    warn_deprecated_function,
+    warn_obsolete_guard,
+    strict_validation,
+    warn_export_vars,
+    warn_exported_vars,
+    debug_info
+]}.
+
+{deps, [
+    {dynamic_compile, ".*", {git, "https://github.com/okeuday/dynamic_compile.git", {tag, "v1.0.0"}}}
+]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,8 @@
+IsRebar3 = erlang:function_exported(rebar3, main, 1),
+case IsRebar3 of
+    false ->
+        {ok, OldConfig} = file:consult("old.rebar.config"),
+        OldConfig;
+    true ->
+        CONFIG
+end.


### PR DESCRIPTION
After the changes introduced in #33, this library became unusable with old versions of rebar. It's now a rebar3 only library. But some projects still need to use it with the old rebar, so we're adding a rebar.config.script and a basic rebar.config for them.