### PR TITLE
Add option to be able to provide an MFA for cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If instead of using ElastiCache a custom auto discovery is needed you can provid
 
 -export([my_function/0]).
 
-my_fFunction() ->
+my_function() ->
   {ok, [{"my_memcached_server", 11211}]}.
 
 ``` 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Provide the configuration endpoint ([AWS Reference](http://docs.aws.amazon.com/A
 If instead of using ElastiCache a custom auto discovery is needed you can provide your own function (specified as a MFA) that returns `{ok, list({Host :: inet:hostname(), Port :: inet:port_number()})}` to be used. Example:
 ```erlang
     [{cluster_b,
-        [{servers, {mfa, {myModule, myFunction, []}}},
+        [{servers, {mfa, {my_module, my_function, []}}},
              {sharding_algorithm, {mero, shard_crc32}},
              {workers_per_shard, 1},
              {pool_worker_module, mero_wrk_tcp_binary}]
@@ -101,12 +101,12 @@ If instead of using ElastiCache a custom auto discovery is needed you can provid
 ```
 
 ```erlang
--module(myModule).
+-module(my_module).
 
--export([myFunction/0]).
+-export([my_function/0]).
 
-myFunction() ->
-  {ok, [{"myMemcachedServer", 11211}]}.
+my_fFunction() ->
+  {ok, [{"my_memcached_server", 11211}]}.
 
 ``` 
 

--- a/src/mero_conf.erl
+++ b/src/mero_conf.erl
@@ -290,13 +290,16 @@ process_value({servers, {elasticache, ConfigList}}) when is_list(ConfigList) ->
         end,
     {servers, lists:flatten(HostsPorts)};
 process_value({servers, {mfa, {Module, Function, Args}}}) ->
-    case catch erlang:apply(Module, Function, Args) of
-        {ok, HostsPorts} when is_list(HostsPorts) ->
-            {servers, HostsPorts};
-        {'EXIT', Error} ->
-            error(Error);
-        InvalidResponse ->
-            error({invalid_response, {Module, Function, Args}, InvalidResponse})
+    try
+        case erlang:apply(Module, Function, Args) of
+            {ok, HostsPorts} when is_list(HostsPorts) ->
+                {servers, HostsPorts};
+            InvalidResponse ->
+                error({invalid_response, {Module, Function, Args}, InvalidResponse})
+        end
+    catch
+        Type:Reason ->
+            error({invalid_call, {Module, Function, Args}, {Type, Reason}})
     end;
 process_value(V) ->
     V.

--- a/src/mero_conf.erl
+++ b/src/mero_conf.erl
@@ -289,6 +289,15 @@ process_value({servers, {elasticache, ConfigList}}) when is_list(ConfigList) ->
                 lists:map(fun get_elasticache_cluster_configs/1, ConfigList)
         end,
     {servers, lists:flatten(HostsPorts)};
+process_value({servers, {mfa, {Module, Function, Args}}}) ->
+    case catch erlang:apply(Module, Function, Args) of
+        {ok, HostsPorts} when is_list(HostsPorts) ->
+            {servers, HostsPorts};
+        {'EXIT', Error} ->
+            error(Error);
+        InvalidResponse ->
+            error({invalid_response, {Module, Function, Args}, InvalidResponse})
+    end;
 process_value(V) ->
     V.
 

--- a/src/mero_conf.erl
+++ b/src/mero_conf.erl
@@ -290,13 +290,9 @@ process_value({servers, {elasticache, ConfigList}}) when is_list(ConfigList) ->
         end,
     {servers, lists:flatten(HostsPorts)};
 process_value({servers, {mfa, {Module, Function, Args}}}) ->
-    try
-        case erlang:apply(Module, Function, Args) of
-            {ok, HostsPorts} when is_list(HostsPorts) ->
-                {servers, HostsPorts};
-            InvalidResponse ->
-                error({invalid_response, {Module, Function, Args}, InvalidResponse})
-        end
+    try erlang:apply(Module, Function, Args) of
+        {ok, HostsPorts} when is_list(HostsPorts) ->
+            {servers, HostsPorts}
     catch
         Type:Reason ->
             error({invalid_call, {Module, Function, Args}, {Type, Reason}})


### PR DESCRIPTION
Hi!

We find the mero_conf_monitor feature very useful to allow dynamic configuration, but we need to provide our own server list instead of relying on ElastiCache. This branch adds the possibility to specify a custom function to be called to retrieve the server list.
