### PR TITLE
Prevent mero fail when fails a single cluster

### DIFF
--- a/src/mero_conf.erl
+++ b/src/mero_conf.erl
@@ -287,16 +287,17 @@ process_value({servers, {mfa, {Module, Function, Args}}}) ->
 process_value(V) ->
     V.
 
-get_elasticache_cluster_configs({Host, Port, ClusterSpeedFactor}, Retries) ->
-    lists:duplicate(ClusterSpeedFactor, get_elasticache_cluster_config(Host, Port, Retries));
-get_elasticache_cluster_configs({Host, Port}, Retries) ->
-    [get_elasticache_cluster_config(Host, Port, Retries)].
+get_elasticache_cluster_configs({Host, Port, ClusterSpeedFactor}, MaxRetries) ->
+    lists:duplicate(ClusterSpeedFactor,
+                    get_elasticache_cluster_config(Host, Port, MaxRetries));
+get_elasticache_cluster_configs({Host, Port}, MaxRetries) ->
+    [get_elasticache_cluster_config(Host, Port, MaxRetries)].
 
-get_elasticache_cluster_config(Host, Port, Retries) ->
+get_elasticache_cluster_config(Host, Port, MaxRetries) ->
     get_elasticache_cluster_config(Host,
                                    Port,
                                    0,
-                                   Retries,
+                                   MaxRetries,
                                    mero_elasticache:get_cluster_config(Host, Port)).
 
 get_elasticache_cluster_config(_Host, _Port, _CurrentRetry, _MaxRetries, {ok, Entries}) ->

--- a/src/mero_conf.erl
+++ b/src/mero_conf.erl
@@ -270,8 +270,8 @@ process_value({servers, {elasticache, ConfigList}}) when is_list(ConfigList) ->
         catch
             _:badrpc ->
                 % Fallback to sequential execution, mostly to get proper error descriptions
-                lists:map(fun (Config) ->
-                            get_elasticache_cluster_configs(Config, 0) % Avoid unnecesary retries
+                lists:map(fun(Config) ->
+                             get_elasticache_cluster_configs(Config, 0) % Avoid unnecesary retries
                           end,
                           ConfigList)
         end,
@@ -299,14 +299,14 @@ get_elasticache_cluster_config(Host, Port, Retries) ->
                                    Retries,
                                    mero_elasticache:get_cluster_config(Host, Port)).
 
-get_elasticache_cluster_config(_Host, _Port, _Retry, _Retries, {ok, Entries}) ->
+get_elasticache_cluster_config(_Host, _Port, _CurrentRetry, _MaxRetries, {ok, Entries}) ->
     Entries;
-get_elasticache_cluster_config(Host, Port, Retry, Retry, {error, Reason}) ->
+get_elasticache_cluster_config(Host, Port, MaxRetries, MaxRetries, {error, Reason}) ->
     error({Reason, Host, Port});
-get_elasticache_cluster_config(Host, Port, Retry, Retries, {error, _Reason}) ->
-    timer:sleep(trunc(math:pow(2, Retry)) * 100),
+get_elasticache_cluster_config(Host, Port, CurrentRetry, MaxRetries, {error, _Reason}) ->
+    timer:sleep(trunc(math:pow(2, CurrentRetry)) * 100),
     get_elasticache_cluster_config(Host,
                                    Port,
-                                   Retry + 1,
-                                   Retries,
+                                   CurrentRetry + 1,
+                                   MaxRetries,
                                    mero_elasticache:get_cluster_config(Host, Port)).

--- a/src/mero_conf.erl
+++ b/src/mero_conf.erl
@@ -267,7 +267,7 @@ process_value({servers, {elasticache, ConfigList}}) when is_list(ConfigList) ->
         catch
             _:badrpc ->
                 % Fallback to sequential execution, mostly to get proper error descriptions
-                lists:map(fun(Config) -> get_elasticache_cluster_configs(Config) end, ConfigList)
+                lists:map(fun get_elasticache_cluster_configs/1, ConfigList)
         end,
     {servers, lists:flatten(HostsPorts)};
 process_value({servers, {mfa, {Module, Function, Args}}}) ->

--- a/src/mero_sup.erl
+++ b/src/mero_sup.erl
@@ -30,7 +30,7 @@
 
 -author('Miriam Pena <miriam.pena@adroll.com>').
 
--export([start_link/1, restart_child/1, terminate_child/1, init/1]).
+-export([start_link/1, start_child/1, restart_child/1, terminate_child/1, init/1]).
 
 -behaviour(supervisor).
 
@@ -49,11 +49,15 @@
 start_link(OrigConfig) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, #{orig_config => OrigConfig}).
 
+-spec start_child(ClusterName :: atom()) -> ok.
+start_child(ClusterName) ->
+    {ok, _} = supervisor:start_child(?MODULE, cluster_sup_spec(ClusterName)),
+    ok.
+
 -spec restart_child(ClusterName :: atom()) -> ok.
 restart_child(ClusterName) ->
-    _ = supervisor:terminate_child(?MODULE, ClusterName),
-    _ = supervisor:delete_child(?MODULE, ClusterName),
-    {ok, _} = supervisor:start_child(?MODULE, cluster_sup_spec(ClusterName)),
+    terminate_child(ClusterName),
+    start_child(ClusterName),
     ok.
 
 -spec terminate_child(ClusterName :: atom()) -> ok.

--- a/src/mero_sup.erl
+++ b/src/mero_sup.erl
@@ -30,7 +30,7 @@
 
 -author('Miriam Pena <miriam.pena@adroll.com>').
 
--export([start_link/1, restart_child/1, init/1]).
+-export([start_link/1, restart_child/1, terminate_child/1, init/1]).
 
 -behaviour(supervisor).
 
@@ -54,6 +54,12 @@ restart_child(ClusterName) ->
     _ = supervisor:terminate_child(?MODULE, ClusterName),
     _ = supervisor:delete_child(?MODULE, ClusterName),
     {ok, _} = supervisor:start_child(?MODULE, cluster_sup_spec(ClusterName)),
+    ok.
+
+-spec terminate_child(ClusterName :: atom()) -> ok.
+terminate_child(ClusterName) ->
+    _ = supervisor:terminate_child(?MODULE, ClusterName),
+    _ = supervisor:delete_child(?MODULE, ClusterName),
     ok.
 
 %%%===================================================================

--- a/test/mero_conf_SUITE.erl
+++ b/test/mero_conf_SUITE.erl
@@ -37,7 +37,8 @@
 -export([all/0, init_per_testcase/2, end_per_testcase/2, helper_mfa_config_function/0,
          diff/1, process_server_specs_a_compatible/1, process_server_specs_a/1,
          process_server_specs_a_alternate/1, process_server_specs_a_b/1,
-         process_server_specs_a_b_c/1, process_server_specs_mfa/1, per_pool_config/1]).
+         process_server_specs_a_b_c/1, process_server_specs_mfa/1, per_pool_config/1,
+         process_server_specs_with_failure/1]).
 
 all() ->
     [diff,
@@ -47,7 +48,8 @@ all() ->
      process_server_specs_a_b,
      process_server_specs_a_b_c,
      process_server_specs_mfa,
-     per_pool_config].
+     per_pool_config,
+     process_server_specs_with_failure].
 
 init_per_testcase(diff, Conf) ->
     Conf;
@@ -65,22 +67,24 @@ init_per_testcase(_, Conf) ->
           "c3.com|10.102.00.102|11211 c4.com|10.102.00.102|11211\n">>,
     meck:expect(mero_elasticache,
                 request_response,
-                fun(Type, _, _, _) ->
-                   HostLines =
-                       case Type of
-                           a ->
-                               HostLinea;
-                           b ->
-                               HostLineb;
-                           c ->
-                               HostLinec
-                       end,
-                   {ok,
-                    [{banner, <<"CONFIG cluster ...">>},
-                     {version, <<"version1">>},
-                     {hosts, HostLines},
-                     {crlf, <<"\r\n">>},
-                     {eom, <<"END\r\n">>}]}
+                fun (failing_cluster, _, _, _) ->
+                        {error, econnrefused};
+                    (Type, _, _, _) ->
+                        HostLines =
+                            case Type of
+                                a ->
+                                    HostLinea;
+                                b ->
+                                    HostLineb;
+                                c ->
+                                    HostLinec
+                            end,
+                        {ok,
+                        [{banner, <<"CONFIG cluster ...">>},
+                            {version, <<"version1">>},
+                            {hosts, HostLines},
+                            {crlf, <<"\r\n">>},
+                            {eom, <<"END\r\n">>}]}
                 end),
     Conf.
 
@@ -234,4 +238,50 @@ per_pool_config(_Conf) ->
     ?assertEqual(20, mero_conf:pool_initial_connections(pool_3)),
     ?assertEqual(30, mero_conf:pool_initial_connections(pool_1)),
     ?assertEqual(50, mero_conf:pool_initial_connections(pool_2)),
+    ok.
+
+process_server_specs_with_failure(_Conf) ->
+    meck:new(error_logger, [unstick, passthrough]),
+    Spec =
+        [{cluster_a,
+          [{servers, {elasticache, [{a, 11211, 2}]}},
+           {sharding_algorithm, {mero, shard_crc32}},
+           {workers_per_shard, 1},
+           {pool_worker_module, mero_wrk_tcp_binary}]},
+         {cluster_b,
+          [{servers, {elasticache, [{failing_cluster, 11211, 3}]}},
+           {sharding_algorithm, {mero, shard_crc32}},
+           {workers_per_shard, 1},
+           {pool_worker_module, mero_wrk_tcp_binary}]},
+         {cluster_c,
+          [{servers, {elasticache, [{c, 11211, 1}]}},
+           {sharding_algorithm, {mero, shard_crc32}},
+           {workers_per_shard, 1},
+           {pool_worker_module, mero_wrk_tcp_binary}]}],
+    [{cluster_a, ServerSpecsA}, {cluster_b, ServerSpecsB}, {cluster_c, ServerSpecsC}] =
+        mero_conf:process_server_specs(Spec),
+    ?assertEqual([{"a1.com", 11211},
+                  {"a2.com", 11211},
+                  {"a3.com", 11211},
+                  {"a1.com", 11211},
+                  {"a2.com", 11211},
+                  {"a3.com", 11211}],
+                 proplists:get_value(servers, ServerSpecsA)),
+    ?assertEqual(mero_wrk_tcp_binary, proplists:get_value(pool_worker_module, ServerSpecsA)),
+    ?assertEqual(1, proplists:get_value(workers_per_shard, ServerSpecsA)),
+    ?assertEqual({mero, shard_crc32}, proplists:get_value(sharding_algorithm, ServerSpecsA)),
+
+    ?assertEqual(1,
+                 meck:num_calls(error_logger,
+                                error_report,
+                                [[{error, mero_config_failed},
+                                  {kind, error},
+                                  {desc, {econnrefused, failing_cluster, 11211}},
+                                  {stack, '_'}]])),
+    ?assertEqual({error, {econnrefused, failing_cluster, 11211}},
+                 proplists:get_value(servers, ServerSpecsB)),
+
+    ?assertEqual([{"c1.com", 11211}, {"c2.com", 11211}, {"c3.com", 11211}, {"c4.com", 11211}],
+                 proplists:get_value(servers, ServerSpecsC)),
+    meck:unload([error_logger]),
     ok.

--- a/test/mero_conf_SUITE.erl
+++ b/test/mero_conf_SUITE.erl
@@ -80,11 +80,11 @@ init_per_testcase(_, Conf) ->
                                     HostLinec
                             end,
                         {ok,
-                        [{banner, <<"CONFIG cluster ...">>},
-                            {version, <<"version1">>},
-                            {hosts, HostLines},
-                            {crlf, <<"\r\n">>},
-                            {eom, <<"END\r\n">>}]}
+                         [{banner, <<"CONFIG cluster ...">>},
+                          {version, <<"version1">>},
+                          {hosts, HostLines},
+                          {crlf, <<"\r\n">>},
+                          {eom, <<"END\r\n">>}]}
                 end),
     Conf.
 

--- a/test/mero_conf_SUITE.erl
+++ b/test/mero_conf_SUITE.erl
@@ -258,7 +258,7 @@ process_server_specs_with_failure(_Conf) ->
            {sharding_algorithm, {mero, shard_crc32}},
            {workers_per_shard, 1},
            {pool_worker_module, mero_wrk_tcp_binary}]}],
-    [{cluster_a, ServerSpecsA}, {cluster_b, ServerSpecsB}, {cluster_c, ServerSpecsC}] =
+    [{cluster_a, ServerSpecsA}, {cluster_c, ServerSpecsC}] =
         mero_conf:process_server_specs(Spec),
     ?assertEqual([{"a1.com", 11211},
                   {"a2.com", 11211},
@@ -278,8 +278,6 @@ process_server_specs_with_failure(_Conf) ->
                                   {kind, error},
                                   {desc, {econnrefused, failing_cluster, 11211}},
                                   {stack, '_'}]])),
-    ?assertEqual({error, {econnrefused, failing_cluster, 11211}},
-                 proplists:get_value(servers, ServerSpecsB)),
 
     ?assertEqual([{"c1.com", 11211}, {"c2.com", 11211}, {"c3.com", 11211}, {"c4.com", 11211}],
                  proplists:get_value(servers, ServerSpecsC)),

--- a/test/mero_conf_monitor_SUITE.erl
+++ b/test/mero_conf_monitor_SUITE.erl
@@ -36,7 +36,8 @@
 -export([conf_is_periodically_fetched/1, cluster_is_restarted_when_new_nodes/1,
          cluster_is_restarted_when_lost_nodes/1, cluster_is_not_restarted_when_other_changes/1,
          cluster_is_not_restarted_with_bad_info/1, cluster_is_not_restarted_on_socket_error/1,
-         non_heartbeat_messages_are_ignored/1, cluster_fails/1, cluster_fails_and_recovers/1]).
+         non_heartbeat_messages_are_ignored/1, cluster_fails/1, cluster_fails_and_recovers/1,
+         cluster_config_added/1, cluster_config_removed/1]).
 
 all() ->
     [conf_is_periodically_fetched,

--- a/test/mero_conf_monitor_SUITE.erl
+++ b/test/mero_conf_monitor_SUITE.erl
@@ -36,8 +36,7 @@
 -export([conf_is_periodically_fetched/1, cluster_is_restarted_when_new_nodes/1,
          cluster_is_restarted_when_lost_nodes/1, cluster_is_not_restarted_when_other_changes/1,
          cluster_is_not_restarted_with_bad_info/1, cluster_is_not_restarted_on_socket_error/1,
-         non_heartbeat_messages_are_ignored/1, cluster_fails/1, cluster_fails_and_recovers/1,
-         cluster_config_added/1, cluster_config_removed/1]).
+         non_heartbeat_messages_are_ignored/1, cluster_fails/1, cluster_fails_and_recovers/1]).
 
 all() ->
     [conf_is_periodically_fetched,

--- a/test/mero_conf_monitor_SUITE.erl
+++ b/test/mero_conf_monitor_SUITE.erl
@@ -36,7 +36,7 @@
 -export([conf_is_periodically_fetched/1, cluster_is_restarted_when_new_nodes/1,
          cluster_is_restarted_when_lost_nodes/1, cluster_is_not_restarted_when_other_changes/1,
          cluster_is_not_restarted_with_bad_info/1, cluster_is_not_restarted_on_socket_error/1,
-         non_heartbeat_messages_are_ignored/1]).
+         non_heartbeat_messages_are_ignored/1, cluster_fails/1]).
 
 all() ->
     [conf_is_periodically_fetched,
@@ -45,7 +45,8 @@ all() ->
      cluster_is_not_restarted_when_other_changes,
      cluster_is_not_restarted_with_bad_info,
      cluster_is_not_restarted_on_socket_error,
-     non_heartbeat_messages_are_ignored].
+     non_heartbeat_messages_are_ignored,
+     cluster_fails].
 
 init_per_testcase(_, Conf) ->
     meck:new([mero_elasticache, mero_wrk_tcp_binary], [passthrough, no_link]),
@@ -163,6 +164,47 @@ cluster_is_restarted_when_lost_nodes(_) ->
         supervisor:which_children(
             mero_cluster:sup_by_cluster_name(cluster1)),
     ?assertEqual(2, length(NewCluster1Children)),
+    lists:foreach(fun(Child) -> ?assertNot(lists:member(Child, Cluster1Children)) end,
+                  NewCluster1Children),
+    ?assertEqual(Cluster2Children,
+                 supervisor:which_children(
+                     mero_cluster:sup_by_cluster_name(cluster2))),
+    ok.
+
+cluster_fails(_) ->
+    mero_conf:monitor_heartbeat_delay(10000, 10001),
+    start_server(),
+
+    Cluster1Children =
+        supervisor:which_children(
+            mero_cluster:sup_by_cluster_name(cluster1)),
+    Cluster2Children =
+        supervisor:which_children(
+            mero_cluster:sup_by_cluster_name(cluster2)),
+    ?assertEqual(3, length(Cluster1Children)),
+    ?assertEqual(2, length(Cluster2Children)),
+
+    %% Nothing Changed...
+    send_heartbeat(),
+    ?assertEqual(Cluster1Children,
+                 supervisor:which_children(
+                     mero_cluster:sup_by_cluster_name(cluster1))),
+    ?assertEqual(Cluster2Children,
+                 supervisor:which_children(
+                     mero_cluster:sup_by_cluster_name(cluster2))),
+
+    %% Cluster2 stays, Cluster1 refuses connection
+    Lines =
+        #{a => <<"a1.com|10.100.100.100|11112 ", "a2.com|10.101.101.00|11112 ", "a3.com|10.102.00.102|11112\n">>,
+          b => <<"b1.com|10.100.100.100|11212 ", "b2.com|10.101.101.00|11212\n">>},
+    mock_elasticache_fail(Lines),
+
+    %% Cluster1 removed, Cluster2 is rebuilt
+    send_heartbeat(),
+    NewCluster1Children =
+        supervisor:which_children(
+            mero_cluster:sup_by_cluster_name(cluster1)),
+    %?assertEqual(2, length(NewCluster1Children)),
     lists:foreach(fun(Child) -> ?assertNot(lists:member(Child, Cluster1Children)) end,
                   NewCluster1Children),
     ?assertEqual(Cluster2Children,
@@ -327,3 +369,18 @@ mock_elasticache(Lines) ->
 
 mock_elasticache_timeout() ->
     meck:expect(mero_elasticache, request_response, 4, {error, etimedout}).
+
+mock_elasticache_fail(Lines) ->
+    meck:expect(mero_elasticache,
+                request_response,
+                fun (a, _, _, _) ->
+                        {error, econnrefused};
+                    (Type, _, _, _) ->
+                        HostLines = maps:get(Type, Lines),
+                        {ok,
+                         [{banner, <<"CONFIG cluster ...">>},
+                          {version, <<"version1">>},
+                          {hosts, HostLines},
+                          {crlf, <<"\r\n">>},
+                          {eom, <<"END\r\n">>}]}
+                end).

--- a/test/mero_conf_monitor_SUITE.erl
+++ b/test/mero_conf_monitor_SUITE.erl
@@ -46,7 +46,8 @@ all() ->
      cluster_is_not_restarted_with_bad_info,
      cluster_is_not_restarted_on_socket_error,
      non_heartbeat_messages_are_ignored,
-     cluster_fails, cluster_fails_and_recovers].
+     cluster_fails,
+     cluster_fails_and_recovers].
 
 init_per_testcase(_, Conf) ->
     meck:new([mero_elasticache, mero_wrk_tcp_binary], [passthrough, no_link]),
@@ -195,7 +196,10 @@ cluster_fails(_) ->
 
     %% Cluster2 stays, Cluster1 refuses connection
     Lines =
-        #{a => <<"a1.com|10.100.100.100|11112 ", "a2.com|10.101.101.00|11112 ", "a3.com|10.102.00.102|11112\n">>,
+        #{a =>
+              <<"a1.com|10.100.100.100|11112 ",
+                "a2.com|10.101.101.00|11112 ",
+                "a3.com|10.102.00.102|11112\n">>,
           b => <<"b1.com|10.100.100.100|11212 ", "b2.com|10.101.101.00|11212\n">>},
     mock_elasticache_fail(Lines),
 
@@ -234,7 +238,10 @@ cluster_fails_and_recovers(_) ->
 
     %% Cluster2 stays, Cluster1 refuses connection
     Lines =
-        #{a => <<"a1.com|10.100.100.100|11112 ", "a2.com|10.101.101.00|11112 ", "a3.com|10.102.00.102|11112\n">>,
+        #{a =>
+              <<"a1.com|10.100.100.100|11112 ",
+                "a2.com|10.101.101.00|11112 ",
+                "a3.com|10.102.00.102|11112\n">>,
           b => <<"b1.com|10.100.100.100|11212 ", "b2.com|10.101.101.00|11212\n">>},
     mock_elasticache_fail(Lines),
 
@@ -439,12 +446,12 @@ mock_elasticache_fail(Lines) ->
 mock_elasticache_recovered(Lines) ->
     meck:expect(mero_elasticache,
                 request_response,
-                fun (Type, _, _, _) ->
-                        HostLines = maps:get(Type, Lines),
-                        {ok,
-                         [{banner, <<"CONFIG cluster ...">>},
-                          {version, <<"version1">>},
-                          {hosts, HostLines},
-                          {crlf, <<"\r\n">>},
-                          {eom, <<"END\r\n">>}]}
+                fun(Type, _, _, _) ->
+                   HostLines = maps:get(Type, Lines),
+                   {ok,
+                    [{banner, <<"CONFIG cluster ...">>},
+                     {version, <<"version1">>},
+                     {hosts, HostLines},
+                     {crlf, <<"\r\n">>},
+                     {eom, <<"END\r\n">>}]}
                 end).


### PR DESCRIPTION
Now when a single cluster fails in Mero configuration it won't crash. Instead, it will keep working and be able to restore the cluster once it starts working again.

Was tested in a single instance in production, blocking connections to elasticache using `iptables` command. Mero raised an exception but kept working for other clusters, and when the connectivity was restored it recovered.